### PR TITLE
add initial code to redeem list of shares

### DIFF
--- a/.github/workflows/github-actions-clarinet.yml
+++ b/.github/workflows/github-actions-clarinet.yml
@@ -1,0 +1,17 @@
+name: CI
+on: [push]
+jobs:
+  tests:
+    name: "Test contracts with Clarinet"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Execute unit tests"
+        uses: docker://hirosystems/clarinet:latest
+        with:
+          args: test --coverage --manifest-path=./Clarinet.toml
+      - name: "Export code coverage"
+        uses: codecov/codecov-action@v1
+        with:
+          files: ./coverage.lcov
+          verbose: true

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -5,7 +5,7 @@ costs_version = 1
 
 [contracts.token-vesting]
 path = "contracts/token-vesting.clar"
-depends_on = ["sip-010-trait"]
+depends_on = ["sip-010-trait", "xyz-token"]
 
 [contracts.sip-010-trait]
 path = "contracts/sip-010-trait.clar"

--- a/contracts/token-vesting.clar
+++ b/contracts/token-vesting.clar
@@ -2,54 +2,94 @@
 ;; Token Vesting
 ;;
 ;; Vesting contract that allows deposit of SIP-010 tokens.
-;; Withdraws are unlocked to a specified set of addresses
-;; at a certain schedule and conditions.
+;; Withdraws are unlocked and allowed to a specified
+;; set of addresses at a certain schedule and conditions.
 
 ;; SIP-010 token trait.
 (use-trait ft-trait .sip-010-trait.sip-010-trait)
 
 ;;
+;; -- Error codes
+;;
+
+(define-constant share-already-redeemed (err 10))
+
+;;
 ;; -- Data
 ;;
 
-;; Contract owner.
-(define-constant contract-owner tx-sender)
+;; Vestings data structure.
+;; Stores contract vestings.
+(define-map vestings
+  { depositor: principal, token: principal }
+  { amount: uint, locking-period: uint })
 
-;; Treasury map.
-;; Identify and stores vestings for the contract.
-(define-map treasury
-  uint {sender: principal, amount: uint, token-contract: principal})
+;; Shares data structure.
+;; Stores vestings shares.
+(define-map shares
+  (tuple (address principal) (token principal))
+  (tuple (amount uint) (redeemed bool)))
 
-;; Vesting ID.
-(define-data-var vesting-id uint u0)
-
-;; The contract itself is the vesting Vault.
-(define-data-var vesting-vault principal (as-contract tx-sender))
+;; Current token context.
+(define-data-var token-context
+  (optional principal) none)
 
 ;;
 ;; -- Public
 ;;
 
-;; Deposit function.
-(define-public (deposit (token <ft-trait>) (amount uint))
+;; Deposit tokens.
+(define-public (deposit
+  (token <ft-trait>) (amount uint) (locking-period uint) (assignees (list 10 (tuple (address principal) (amount uint)))))
   (begin
-    (map-set treasury
-      (get-next-vesting-id)
-      {
-        sender: tx-sender,
-        amount: amount,
-        token-contract: (contract-of token)
-      })
+    (add-to-vestings token amount locking-period)
+    (var-set token-context (some (contract-of token)))
+    (map add-to-shares assignees)
     (try! (contract-call? token transfer
-      amount tx-sender (var-get vesting-vault) none))
+      amount tx-sender (as-contract tx-sender) none))
+    (ok true)))
+
+;; Finishes a vest,
+;; withdrawing the respective shares.
+(define-public (redeem
+  (token <ft-trait>))
+  (let (
+    (recipient contract-caller)
+    (share (get-share {address: tx-sender, token: (contract-of token)})))
+    (asserts! (not (get redeemed share)) share-already-redeemed)
+    (unwrap-panic (as-contract (contract-call? token transfer
+      (get amount share) tx-sender recipient none)))
+    (mark-share-as-redeemed token)
     (ok true)))
 
 ;;
 ;; -- Private
 ;;
 
-;; Next vesting ID.
-(define-private (get-next-vesting-id)
-  (begin
-    (var-set vesting-id (+ (var-get vesting-id) u1)) ;; increments vesting ID by one
-    (var-get vesting-id)))
+;; Mark share as redeemed.
+;; updates the amount to u0 and
+;; sets redeemed valur to true.
+(define-private (mark-share-as-redeemed
+  (token <ft-trait>))
+  (map-set shares
+    {address: tx-sender, token: (contract-of token)}
+    {amount: u0, redeemed: true}))
+
+;; Add a deposit to the vestings storage.
+(define-private (add-to-vestings
+  (token <ft-trait>) (amount uint) (locking-period uint))
+  (map-set vestings
+    {depositor: tx-sender, token: (contract-of token)}
+    {amount: amount, locking-period: locking-period}))
+
+;; Add a share to the shares storage.
+(define-private (add-to-shares
+  (share (tuple (address principal) (amount uint))))
+  (map-set shares
+    {address: (get address share), token: (unwrap-panic (var-get token-context))}
+    {amount: (get amount share), redeemed: false}))
+
+;; Get amount in the shares storage.
+(define-private (get-share
+  (key (tuple (address principal) (token principal))))
+  (unwrap-panic (map-get? shares key)))

--- a/tests/token-vesting_test.ts
+++ b/tests/token-vesting_test.ts
@@ -10,14 +10,14 @@ import {
     assertEquals
 } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
 
-const addr = 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM';
+const addr = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM";
 const contract = "token-vesting";
+const token = "xyz-token";
 
 /**
  * Bridge to test token
  */
-class TokenBridge {
-
+class ContractBridge {
     chain: Chain;
     deployer: Account;
 
@@ -27,39 +27,68 @@ class TokenBridge {
     }
 
     /**
-     * Get qualified token contract
+     * Get qualified token address
      */
-    getTokenContract(token: string) {
+    getTokenAddress() {
         return `${addr}.${token}`;
+    }
+
+    /**
+     * Get qualified contract address
+     */
+    getAddress() {
+        return `${addr}.${contract}`;
     }
 
     /**
      * Deposit function
      */
-    deposit(token:string, amount: number) {
+    deposit(token: string, amount: number, lockingPeriod: number, assignees: { address: string, amount: number }[]) {
+        let assigneesList: any[] = [];
+        assignees.forEach((el) => {
+            assigneesList.push(
+                types.tuple({
+                    'address': types.principal(el.address),
+                    'amount': types.uint(el.amount)
+                })
+            )
+        });
+
         const block = this.chain.mineBlock([
 			      Tx.contractCall(
                 contract,
                 'deposit',
                 [
-                    types.principal(this.getTokenContract(token)),
-                    types.uint(amount)
+                    types.principal(this.getTokenAddress()),
+                    types.uint(amount),
+                    types.uint(lockingPeriod),
+                    types.list(assigneesList)
                 ],
                 this.deployer.address
             )
-		    ]);
+	      ]);
 
-        return block.receipts[0].result;
+        return block.receipts[0];
     }
 }
 
 Clarinet.test({
-    name: "allows a deposit",
+    name: "[deposit] amount to be locked is transferred to the contract",
     async fn(chain: Chain, accounts: Map<string, Account>) {
-        const amount = 100;
-        const token = new TokenBridge(chain, accounts.get("deployer")!);
-        const result = token.deposit("xyz-token", amount);
+        const deployer = accounts.get("deployer")!;
+        const amount = 1020;
+        const lockingPeriod = 48;
+        const assignees = [{
+            address: accounts.get("wallet_3")!.address,
+            amount: 25
+        }];
 
-        result.expectOk().expectBool(true);
+        const contract = new ContractBridge(chain, deployer);
+        const resp = contract.deposit(token, amount, lockingPeriod, assignees);
+        const [transferEvent, _] = resp.events
+
+        resp.result.expectOk().expectBool(true);
+        transferEvent.ft_transfer_event.amount.expectInt(amount);
+        transferEvent.ft_transfer_event.recipient.expectPrincipal(contract.getAddress());
     }
 });


### PR DESCRIPTION
This PR adds an initial implementation for the redeem feature where the beneficiary of a vesting (an address in the shares list) can withdraw it's share.

Question: This PR makes an assumption that only the beneficiary of the vesting can redeem a share. Is that correct?